### PR TITLE
ci: Add GitHub Actions workflows for build and release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 mohamed hamdi <haamdi@outlook.com>
+#
+# SPDX-License-Identifier: ISC
+
+# .github/workflows/build.yml
+name: Build on PR
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install tools with Mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true   # runs `mise install` using your mise.toml
+          cache: true     # caches Mise & tool shims for speed
+
+      - name: Bootstrap Go & Web dependencies
+        run: |
+          make setup            # downloads Go modules and node packages
+
+      - name: Compile frontend & server
+        run: |
+          make all              # generate + build server (dist/readeck)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2025 mohamed hamdi <haamdi@outlook.com>
+#
+# SPDX-License-Identifier: ISC
+
+name: Release on Tag
+
+on:
+  push:
+    tags:
+      - '*'      # any new tag
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      OUTNAME: readeck
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install tools with Mise
+        uses: jdx/mise-action@v2
+        with:
+          install: true
+          cache: true
+
+      - name: Bootstrap Go & Web deps
+        run: |
+          make setup
+
+      - name: Build web assets
+        run: make generate
+
+      - name: Build Linux amd64
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+            make xbuild/linux/amd64
+
+      - name: Build Linux arm64
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
+            make xbuild/linux/arm64
+
+      - name: Build Linux armv7
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 \
+            make xbuild
+
+      - name: Publish Release with assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*linux-amd64
+            dist/*linux-arm64
+            dist/*linux-arm

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025 mohamed hamdi <haamdi@outlook.com>
+#
+# SPDX-License-Identifier: ISC
+
+[tools]
+go = "1.24.1"
+make = "4.4.1"
+node = "22.14.0"


### PR DESCRIPTION
Add two new GitHub Actions workflows to automate build and release processes.

The `.github/workflows/build.yaml` workflow is configured to run on pushes to the `main` branch and on pull requests targeting `main`. Its primary purpose is to verify that the project builds correctly using specified tool versions. It checks out the code, installs required tools via mise, bootstraps dependencies using `make setup`, and compiles the frontend and server with `make all`.

The `.github/workflows/release.yaml` workflow is triggered on the creation of any new Git tag. This workflow is designed to build static, position-independent executables for Linux across different architectures and publish them as assets on a new GitHub release associated with the tag. It follows a similar initial setup (checkout, mise install, make setup, make generate for web assets) but then proceeds to build static binaries for `linux/amd64`, `linux/arm64`, and `linux/armv7` using CGO_ENABLED=0 and specific GOOS/GOARCH/GOARM settings with `make xbuild`. Finally, it uses `softprops/action-gh-release` to upload the generated binaries from the `dist/` directory as release assets.

The `mise.toml` file was added to specify the exact versions of key tools required for the build process: go 1.24.1, make 4.4.1, and node 22.14.0. This ensures consistent build environments in the CI workflows by leveraging `jdx/mise-action`.