### PR TITLE
feat(bookmarks/api): Add endpoint to get bookmark counts

### DIFF
--- a/docs/api/api.yaml
+++ b/docs/api/api.yaml
@@ -115,6 +115,13 @@ paths:
         - "traits.yaml#.deferred"
         - "bookmarks/routes.yaml#.create"
 
+  /bookmarks/count:
+    get:
+      tags: [bookmarks]
+      $merge:
+        - "traits.yaml#.authenticated"
+        - "bookmarks/routes.yaml#.count"
+
   /bookmarks/{id}:
     $merge:
       - "bookmarks/routes.yaml#.withBookmark"

--- a/docs/api/bookmarks/routes.yaml
+++ b/docs/api/bookmarks/routes.yaml
@@ -149,6 +149,17 @@ list:
             type: array
             items:
               $ref: "#/components/schemas/bookmarkSummary"
+# GET /bookmarks/count
+count:
+  summary: Bookmark Count
+  description: Returns the number of bookmarks in the database.
+  responses:
+    "200":
+      description: Number of bookmarks
+      content:
+        application/json:
+          schema:
+            $ref:  "#/components/schemas/bookmarkCount"
 
 # POST /bookmarks
 create:

--- a/docs/api/bookmarks/types.yaml
+++ b/docs/api/bookmarks/types.yaml
@@ -114,7 +114,7 @@ schemas:
       reading_time:
         type: integer
         minimum: 0
-        description: | 
+        description: |
           Duration of the article, in minutes. Either the actual duration for a
           video or a reading time based on the word count.
       resources:
@@ -164,6 +164,29 @@ schemas:
           width:
             type: integer
             description: Image width
+
+bookmarkCount:
+  type: object
+  description: Summary counts of bookmarks
+  properties:
+    total:
+      type: integer
+      description: Number of bookmarks
+    unread:
+      type: integer
+      description: Number of unread bookmarks
+    archived:
+      type: integer
+      description: Number of archived bookmarks
+    marked:
+      type: integer
+      description: Number of marked bookmarks
+    by_type:
+      type: object
+      description: Breakdown of bookmarks by type
+      additionalProperties:
+        type: integer
+
 
   bookmarkInfo:
     allOf:


### PR DESCRIPTION
Add a new API endpoint to retrieve summary counts for bookmarks.

- Added the `/bookmarks/count` path definition to `docs/api/api.yaml`, specifying a GET method that is authenticated and merges the route definition for the count endpoint.
- Defined the `count` endpoint details in `docs/api/bookmarks/routes.yaml`, including its summary "Bookmark Count", a description, and the expected 200 response structure.
- Introduced the `bookmarkCount` schema in `docs/api/bookmarks/types.yaml` to describe the structure of the response payload for the count endpoint. This schema includes fields for total, unread, archived, and marked bookmark counts, and a `by_type` object providing a breakdown by bookmark type.
- Implemented the `bookmarkCount` handler function in `internal/bookmarks/routes/api_bookmarks.go`. This function retrieves the count data using the bookmarks service's `CountAll` method, maps the result to the newly defined `bookmarkCount` struct, and renders the JSON response.
- Defined the `bookmarkCount` Go struct in `internal/bookmarks/routes/api_bookmarks.go` to represent the response payload for the count endpoint, ensuring it matches the OpenAPI schema.
- Configured the `GET /bookmarks/count` route in `internal/bookmarks/routes/http.go`, assigning the `bookmarkCount` handler and applying the `withBookmarkList` middleware for contextual data.